### PR TITLE
fix: prevent NullPointerException in RangedBeacon and update Android …

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,9 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.BLUETOOTH" android:required="false"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:required="false"/>
+    <uses-permission android:name="android.permission.BLUETOOTH" android:required="false" android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:required="false" android:maxSdkVersion="30"/>
+    <!-- Required for Android 12+ (API 31+) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:required="false"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" android:required="false"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" android:required="false"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <application>
         <receiver android:name="org.altbeacon.beacon.startup.StartupBroadcastReceiver" android:exported="false">

--- a/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -30,6 +30,10 @@ public class RangedBeacon implements Serializable {
     }
 
     public void updateBeacon(Beacon beacon) {
+        if (beacon == null) {
+            LogManager.w(TAG, "updateBeacon called with null beacon, ignoring");
+            return;
+        }
         packetCount += 1;
         mBeacon = beacon;
         if(firstCycleDetectionTimestamp == 0) {
@@ -53,6 +57,10 @@ public class RangedBeacon implements Serializable {
 
     // Done at the end of each cycle before data are sent to the client
     public void commitMeasurements() {
+        if (mBeacon == null) {
+            LogManager.w(TAG, "commitMeasurements called with null beacon, ignoring");
+            return;
+        }
          if (!getFilter().noMeasurementsAvailable()) {
              double runningAverage = getFilter().calculateRssi();
              mBeacon.setRunningAverageRssi(runningAverage);


### PR DESCRIPTION
…12+ permissions

- Add null checks in RangedBeacon.updateBeacon() and commitMeasurements() to prevent crashes when beacon is null
- Update AndroidManifest.xml with required Android 12+ (API 31+) Bluetooth permissions
- Add maxSdkVersion="30" to legacy Bluetooth permissions for proper targeting
- Add ACCESS_FINE_LOCATION permission required for newer Android versions

Fixes crash affecting 496 users: org.altbeacon.beacon.service.RangedBeacon.addM... NullPointerException